### PR TITLE
Update Cinema filters: port features from TTK stable

### DIFF
--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -3,6 +3,7 @@
 # also register the xml file if given
 
 file(READ "CMake/debug_widgets.xml" DEBUG_WIDGETS)
+file(READ "CMake/topological_compression.xml" TOPOLOGICAL_COMPRESSION_WIDGETS)
 
 macro(ttk_register_pv_filter vtkModuleDir xmlFile)
   if(NOT EXISTS "${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module")

--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -2,32 +2,7 @@
 # deduce the location of the corresonding vtk.module file
 # also register the xml file if given
 
-set(DEBUG_WIDGETS "\
-<IntVectorProperty name='Debug_UseAllCores' label='Use All Cores' command='SetUseAllCores' number_of_elements='1' default_values='1' panel_visibility='advanced'>\
-    <BooleanDomain name='bool' />\
-    <Documentation>Use all available cores.</Documentation>\
-</IntVectorProperty>\
-<IntVectorProperty name='Debug_ThreadNumber' label='Thread Number' command='SetThreadNumber' number_of_elements='1' default_values='1' panel_visibility='advanced'>\
-    <IntRangeDomain name='range' min='1' max='256' />\
-    <Hints>\
-        <PropertyWidgetDecorator type='GenericDecorator' mode='visibility' property='Debug_UseAllCores' value='0' />\
-    </Hints>\
-    <Documentation>The maximum number of threads.</Documentation>\
-</IntVectorProperty>\
-<IntVectorProperty name='Debug_DebugLevel' label='Debug Level' command='SetDebugLevel' number_of_elements='1' default_values='3' panel_visibility='advanced'>\
-    <IntRangeDomain name='range' min='0' max='5' />\
-    <Documentation>Debug level.</Documentation>\
-</IntVectorProperty>\
-<Property name='Debug_Execute' label='Execute' command='Modified' panel_widget='command_button' panel_visibility='advanced'>\
-    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>\
-</Property>\
-<PropertyGroup panel_widget='Line' label='Testing'>\
-    <Property name='Debug_UseAllCores' />\
-    <Property name='Debug_ThreadNumber' />\
-    <Property name='Debug_DebugLevel' />\
-    <Property name='Debug_Execute' />\
-</PropertyGroup>\
-")
+file(READ "CMake/debug_widgets.xml" DEBUG_WIDGETS)
 
 macro(ttk_register_pv_filter vtkModuleDir xmlFile)
   if(NOT EXISTS "${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module")

--- a/CMake/debug_widgets.xml
+++ b/CMake/debug_widgets.xml
@@ -1,0 +1,54 @@
+<IntVectorProperty name='Debug_UseAllCores'
+                   label='Use All Cores'
+                   command='SetUseAllCores'
+                   number_of_elements='1'
+                   default_values='1'
+                   panel_visibility='advanced'>
+  <BooleanDomain name='bool' />
+  <Documentation>Use all available cores.</Documentation>
+</IntVectorProperty>
+
+<IntVectorProperty name='Debug_ThreadNumber'
+                   label='Thread Number'
+                   command='SetThreadNumber'
+                   number_of_elements='1'
+                   default_values='1'
+                   panel_visibility='advanced'>
+  <IntRangeDomain name='range' min='1' max='256' />
+  <Hints>
+    <PropertyWidgetDecorator type='GenericDecorator'
+                             mode='visibility'
+                             property='Debug_UseAllCores'
+                             value='0' />
+  </Hints>
+  <Documentation>The maximum number of threads.</Documentation>
+</IntVectorProperty>
+
+<IntVectorProperty name='Debug_DebugLevel'
+                   label='Debug Level'
+                   command='SetDebugLevel'
+                   number_of_elements='1'
+                   default_values='3'
+                   panel_visibility='advanced'>
+  <IntRangeDomain name='range' min='0' max='5' />
+  <Documentation>Debug level.</Documentation>
+</IntVectorProperty>
+
+<Property name='Debug_Execute'
+          label='Execute'
+          command='Modified'
+          panel_widget='command_button'
+          panel_visibility='advanced'>
+  <Documentation>
+    Executes the filter with the last applied parameters, which is
+    handy to re-start pipeline execution from a specific element
+    without changing parameters.
+  </Documentation>
+</Property>
+
+<PropertyGroup panel_widget='Line' label='Testing'>
+  <Property name='Debug_UseAllCores' />
+  <Property name='Debug_ThreadNumber' />
+  <Property name='Debug_DebugLevel' />
+  <Property name='Debug_Execute' />
+</PropertyGroup>

--- a/CMake/topological_compression.xml
+++ b/CMake/topological_compression.xml
@@ -1,0 +1,124 @@
+<StringVectorProperty
+    name="ScalarField"
+    command="SetScalarField"
+    number_of_elements="1"
+    animateable="0"
+    label="Scalar Field">
+  <ArrayListDomain
+      name="array_list"
+      default_values="0">
+    <RequiredProperties>
+      <Property name="Input" function="Input" />
+    </RequiredProperties>
+  </ArrayListDomain>
+  <Documentation>
+    Select the scalar field to process.
+  </Documentation>
+</StringVectorProperty>
+
+<IntVectorProperty
+    name="CompressionType"
+    label="Compression type"
+    command="SetCompressionType"
+    number_of_elements="1"
+    default_values="0">
+  <EnumerationDomain name="enum">
+    <Entry value="0" text="Driven by persistence diagram"/>
+  </EnumerationDomain>
+  <Documentation>
+    Compression Type.
+  </Documentation>
+</IntVectorProperty>
+
+<DoubleVectorProperty
+    name="Tolerance"
+    command="SetTolerance"
+    label="Topological loss (persistence percentage)"
+    number_of_elements="1"
+    default_values="10">
+  <Documentation>
+    Topological loss expressed as a persistence threshold (normalized
+    between 0 and 100).
+  </Documentation>
+  <DoubleRangeDomain name="range" min="1" max="100" />
+</DoubleVectorProperty>
+
+<IntVectorProperty
+    name="Subdivide"
+    label="Enable maximum pointwise error control"
+    command="SetSubdivide"
+    number_of_elements="1"
+    default_values="0">
+  <BooleanDomain name="bool"/>
+  <Documentation>
+    Enable maximum pointwise error control.
+  </Documentation>
+</IntVectorProperty>
+
+<DoubleVectorProperty
+    name="MaximumError"
+    command="SetMaximumError"
+    label="Maximum pointwise error (percentage)"
+    number_of_elements="1"
+    default_values="10">
+  <Documentation>
+    Set the maximum allowed pointwise error (in percentage of the
+    function span).
+  </Documentation>
+  <DoubleRangeDomain name="range" min="1" max="100" />
+</DoubleVectorProperty>
+
+<IntVectorProperty
+    name="ZFPBitBudget"
+    label="ZFP bit budget (extra)"
+    command="SetZFPBitBudget"
+    number_of_elements="1"
+    default_values="0">
+  <IntRangeDomain name="range" min="0" max="64" />
+  <Documentation>
+    Additionally compress the data with ZFP for improved geometrical
+    quality (number of bits per vertex).
+  </Documentation>
+</IntVectorProperty>
+
+<IntVectorProperty
+    name="ZFPOnly"
+    label="Use ZFP compressor only (no topological compression)"
+    command="SetZFPOnly"
+    number_of_elements="1"
+    default_values="0">
+  <BooleanDomain name="bool"/>
+  <Documentation>
+    Use ZFP only.
+  </Documentation>
+</IntVectorProperty>
+
+<IntVectorProperty
+    name="UseTopologicalSimplification"
+    label="Simplify at compression (slower)"
+    command="SetUseTopologicalSimplification"
+    number_of_elements="1"
+    default_values="1"
+    panel_visibility="advanced">
+  <BooleanDomain name="bool"/>
+  <Documentation>
+    Enable topological simplification at compression time (higher
+    compression factors, slower compression time).
+  </Documentation>
+</IntVectorProperty>
+
+<IntVectorProperty
+    name="SQMethod"
+    command="SetSQMethodPV"
+    animateable="0"
+    label="Use SQ compressor only (no topological compression)"
+    panel_visibility="advanced">
+  <EnumerationDomain name="enum">
+    <Entry value="0" text="No SQ (topological compression)."/>
+    <Entry value="1" text="Range-based SQ (lowest quality, faster)."/>
+    <Entry value="2" text="Domain-based SQ (highest quality, slower)."/>
+  </EnumerationDomain>
+  <Documentation>
+    Use SQ instead of topological compression.
+  </Documentation>
+</IntVectorProperty>

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -54,6 +54,9 @@ vtkSmartPointer<vtkDataObject>
 
   if(pathToFile.substr(pathToFile.length() - 4, 4).compare(".ttk") == 0) {
     return readFileLocal_(pathToFile, this->topologicalCompressionReader);
+  } else if(pathToFile.substr(pathToFile.size() - 4) == ".tif"
+            || pathToFile.substr(pathToFile.size() - 5) == ".tiff") {
+    return readFileLocal_(pathToFile, this->tiffReader);
   } else {
     // Check if dataset is XML encoded
     ifstream is(pathToFile.data());

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -36,8 +36,8 @@ int ttkCinemaProductReader::FillOutputPortInformation(int port,
 }
 
 template <class readerT>
-vtkSmartPointer<vtkDataObject>
-  readFileLocal_(std::string pathToFile, vtkSmartPointer<readerT> &reader) {
+vtkSmartPointer<vtkDataObject> readFileLocal_(std::string pathToFile,
+                                              vtkNew<readerT> &reader) {
   reader->SetFileName(pathToFile.data());
   reader->Update();
   if(reader->GetErrorCode() != 0)
@@ -52,8 +52,8 @@ vtkSmartPointer<vtkDataObject>
 vtkSmartPointer<vtkDataObject>
   ttkCinemaProductReader::readFileLocal(std::string pathToFile) {
 
-  if(pathToFile.substr(pathToFile.length()-4,4).compare(".ttk")==0){
-    return readFileLocal_(pathToFile, this->ttkTopologicalCompressionReader_);
+  if(pathToFile.substr(pathToFile.length() - 4, 4).compare(".ttk") == 0) {
+    return readFileLocal_(pathToFile, this->topologicalCompressionReader);
   } else {
     // Check if dataset is XML encoded
     ifstream is(pathToFile.data());

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -53,6 +53,7 @@ vtkSmartPointer<vtkDataObject>
   ttkCinemaProductReader::readFileLocal(std::string pathToFile) {
 
   if(pathToFile.substr(pathToFile.length() - 4, 4).compare(".ttk") == 0) {
+    this->topologicalCompressionReader->SetDebugLevel(this->debugLevel_);
     return readFileLocal_(pathToFile, this->topologicalCompressionReader);
   } else if(pathToFile.substr(pathToFile.size() - 4) == ".tif"
             || pathToFile.substr(pathToFile.size() - 5) == ".tiff") {

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -36,13 +36,15 @@ int ttkCinemaProductReader::FillOutputPortInformation(int port,
 }
 
 template <class readerT>
-vtkSmartPointer<vtkDataObject> readFileLocal_(std::string pathToFile, vtkSmartPointer<readerT>& reader){
+vtkSmartPointer<vtkDataObject>
+  readFileLocal_(std::string pathToFile, vtkSmartPointer<readerT> &reader) {
   reader->SetFileName(pathToFile.data());
   reader->Update();
   if(reader->GetErrorCode() != 0)
     return nullptr;
 
-  auto result = vtkSmartPointer<vtkDataObject>::Take( reader->GetOutput()->NewInstance() );
+  auto result
+    = vtkSmartPointer<vtkDataObject>::Take(reader->GetOutput()->NewInstance());
   result->ShallowCopy(reader->GetOutput());
   return result;
 }
@@ -138,7 +140,7 @@ int ttkCinemaProductReader::RequestData(vtkInformation *request,
         }
 
         auto readerOutput = this->readFileLocal(path);
-        if(!readerOutput){
+        if(!readerOutput) {
           this->printErr("Unable to read file.");
           return 0;
         }

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -24,6 +24,7 @@
 
 #include <ttkTopologicalCompressionReader.h>
 #include <vtkGenericDataObjectReader.h>
+#include <vtkNew.h>
 #include <vtkSmartPointer.h>
 #include <vtkXMLGenericDataObjectReader.h>
 
@@ -58,14 +59,11 @@ private:
   bool AddFieldDataRecursively{true};
 
   // TTK READER
-  vtkSmartPointer<ttkTopologicalCompressionReader> ttkTopologicalCompressionReader_
-    = vtkSmartPointer<ttkTopologicalCompressionReader>::New();
+  vtkNew<ttkTopologicalCompressionReader> topologicalCompressionReader{};
 
   // LOCAL-LEGACY && REMOTE-LEGACY
-  vtkSmartPointer<vtkGenericDataObjectReader> genericDataObjectReader
-    = vtkSmartPointer<vtkGenericDataObjectReader>::New();
+  vtkNew<vtkGenericDataObjectReader> genericDataObjectReader{};
 
   // LOCAL-XML
-  vtkSmartPointer<vtkXMLGenericDataObjectReader> xmlGenericDataObjectReader
-    = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();
+  vtkNew<vtkXMLGenericDataObjectReader> xmlGenericDataObjectReader{};
 };

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -22,10 +22,10 @@
 // VTK includes
 #include <ttkAlgorithm.h>
 
+#include <ttkTopologicalCompressionReader.h>
 #include <vtkGenericDataObjectReader.h>
 #include <vtkSmartPointer.h>
 #include <vtkXMLGenericDataObjectReader.h>
-#include <ttkTopologicalCompressionReader.h>
 
 class TTKCINEMAPRODUCTREADER_EXPORT ttkCinemaProductReader
   : public ttkAlgorithm {

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -26,6 +26,7 @@
 #include <vtkGenericDataObjectReader.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
+#include <vtkTIFFReader.h>
 #include <vtkXMLGenericDataObjectReader.h>
 
 class TTKCINEMAPRODUCTREADER_EXPORT ttkCinemaProductReader
@@ -60,6 +61,9 @@ private:
 
   // TTK READER
   vtkNew<ttkTopologicalCompressionReader> topologicalCompressionReader{};
+
+  // TIFF READER
+  vtkNew<vtkTIFFReader> tiffReader{};
 
   // LOCAL-LEGACY && REMOTE-LEGACY
   vtkNew<vtkGenericDataObjectReader> genericDataObjectReader{};

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -94,20 +94,16 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
   // -------------------------------------------------------------------------
   // Get Correct Data Product Extension
   // -------------------------------------------------------------------------
-  auto xmlWriter = vtkXMLDataObjectWriter::NewWriter(
-    input->GetDataObjectType()
-  );
+  auto xmlWriter
+    = vtkXMLDataObjectWriter::NewWriter(input->GetDataObjectType());
   xmlWriter->SetDataModeToAppended();
   xmlWriter->SetCompressorTypeToZLib();
-  vtkZLibDataCompressor::SafeDownCast(
-    xmlWriter->GetCompressor()
-  )->SetCompressionLevel(this->CompressionLevel);
+  vtkZLibDataCompressor::SafeDownCast(xmlWriter->GetCompressor())
+    ->SetCompressionLevel(this->CompressionLevel);
 
   std::string productExtension = this->Mode == 0
-    ? xmlWriter->GetDefaultFileExtension()
-    : this->Mode == 1
-      ? "png"
-      : "ttk";
+                                   ? xmlWriter->GetDefaultFileExtension()
+                                   : this->Mode == 1 ? "png" : "ttk";
 
   // -------------------------------------------------------------------------
   // Prepare Field Data
@@ -203,12 +199,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     // -------------------------------------------------------------------------
     if(stat(csvPath.data(), &info) != 0) {
       ttk::Timer t;
-      this->printMsg(
-        "Creating data.csv file",
-        0,
-        ttk::debug::LineMode::REPLACE,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Creating data.csv file", 0, ttk::debug::LineMode::REPLACE,
+                     ttk::debug::Priority::DETAIL);
 
       ofstream csvFile;
       csvFile.open(csvPath.data());
@@ -231,13 +223,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       // Close file
       csvFile.close();
 
-      this->printMsg(
-        "Creating data.csv file",
-        1,
-        t.getElapsedTime(),
-        ttk::debug::LineMode::NEW,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Creating data.csv file", 1, t.getElapsedTime(),
+                     ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);
     }
 
     // -------------------------------------------------------------------------
@@ -257,12 +244,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     auto csvTable = vtkSmartPointer<vtkTable>::New();
     {
       ttk::Timer t;
-      this->printMsg(
-        "Reading data.csv file",
-        0,
-        ttk::debug::LineMode::REPLACE,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Reading data.csv file", 0, ttk::debug::LineMode::REPLACE,
+                     ttk::debug::Priority::DETAIL);
 
       auto reader = vtkSmartPointer<vtkDelimitedTextReader>::New();
       reader->SetFileName(csvPath.data());
@@ -278,12 +261,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
 
       csvTable->ShallowCopy(readerOutput);
 
-      this->printMsg(
-        "Reading data.csv file",
-        1, t.getElapsedTime(),
-        ttk::debug::LineMode::NEW,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Reading data.csv file", 1, t.getElapsedTime(),
+                     ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);
     }
 
     // check CSV file integrity
@@ -356,12 +335,9 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
 
       if(rowsToDelete.size() > 0) {
         ttk::Timer t;
-        this->printMsg(
-          "Deleting products with same keys",
-          0,
-          ttk::debug::LineMode::REPLACE,
-          ttk::debug::Priority::DETAIL
-        );
+        this->printMsg("Deleting products with same keys", 0,
+                       ttk::debug::LineMode::REPLACE,
+                       ttk::debug::Priority::DETAIL);
 
         for(int i = rowsToDelete.size() - 1; i >= 0; i--) {
           auto path = fileColumn->GetValue(rowsToDelete[i]);
@@ -373,13 +349,9 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
           csvTable->RemoveRow(rowsToDelete[i]);
         }
 
-        this->printMsg(
-          "Deleting products with same keys",
-          1,
-          t.getElapsedTime(),
-          ttk::debug::LineMode::NEW,
-          ttk::debug::Priority::DETAIL
-        );
+        this->printMsg("Deleting products with same keys", 1,
+                       t.getElapsedTime(), ttk::debug::LineMode::NEW,
+                       ttk::debug::Priority::DETAIL);
       }
     }
 
@@ -388,12 +360,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     // -----------------------------------------------------------------
     {
       ttk::Timer t;
-      this->printMsg(
-        "Updating data.csv file",
-        0,
-        ttk::debug::LineMode::REPLACE,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Updating data.csv file", 0, ttk::debug::LineMode::REPLACE,
+                     ttk::debug::Priority::DETAIL);
 
       size_t rowIndex = csvTable->GetNumberOfRows();
       csvTable->InsertNextBlankRow();
@@ -410,12 +378,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       csvWriter->SetInputData(csvTable);
       csvWriter->Write();
 
-      this->printMsg(
-        "Updating data.csv file",
-        1, t.getElapsedTime(),
-        ttk::debug::LineMode::NEW,
-        ttk::debug::Priority::DETAIL
-      );
+      this->printMsg("Updating data.csv file", 1, t.getElapsedTime(),
+                     ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);
     }
   }
 
@@ -425,19 +389,15 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
   {
     // Write input to disk
     ttk::Timer t;
-    this->printMsg(
-      "Writing data product to disk",
-      0,
-      ttk::debug::LineMode::REPLACE,
-      ttk::debug::Priority::DETAIL
-    );
+    this->printMsg("Writing data product to disk", 0,
+                   ttk::debug::LineMode::REPLACE, ttk::debug::Priority::DETAIL);
 
     if(this->Mode == 0) {
       xmlWriter->SetFileName(
         (this->DatabasePath + "/" + rDataProductPath).data());
       xmlWriter->SetInputData(input);
       xmlWriter->Write();
-    } else if (this->Mode == 1) {
+    } else if(this->Mode == 1) {
       auto inputAsID = vtkImageData::SafeDownCast(input);
       if(!inputAsID) {
         this->printErr("PNG format requires input of type 'vtkImageData'.");
@@ -477,12 +437,8 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       topologicalCompressionWriter->WriteData();
     }
 
-    this->printMsg(
-      "Writing data product to disk",
-      1, t.getElapsedTime(),
-      ttk::debug::LineMode::NEW,
-      ttk::debug::Priority::DETAIL
-    );
+    this->printMsg("Writing data product to disk", 1, t.getElapsedTime(),
+                   ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);
   }
   this->printMsg(ttk::debug::Separator::L2, ttk::debug::Priority::DETAIL);
   return 1;
@@ -495,7 +451,8 @@ int ttkCinemaWriter::RequestData(vtkInformation *request,
 
   // Print Status
   {
-    std::string modeS = this->Mode==0 ? "VTK" : this->Mode==1 ? "PNG" : "TTK";
+    std::string modeS
+      = this->Mode == 0 ? "VTK" : this->Mode == 1 ? "PNG" : "TTK";
     this->printMsg({{"Database", this->DatabasePath},
                     {"C. Level", std::to_string(this->CompressionLevel)},
                     {"Format", modeS},

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -90,6 +90,12 @@ int ttkCinemaWriter::DeleteDatabase() {
 // =============================================================================
 int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
 
+  // deal with multi-block inputs (no XML writer available)
+  if(input->GetDataObjectType() == VTK_MULTIBLOCK_DATA_SET) {
+    // take the first block only?
+    input = vtkMultiBlockDataSet::SafeDownCast(input)->GetBlock(0);
+  }
+
   // -------------------------------------------------------------------------
   // Get Correct Data Product Extension
   // -------------------------------------------------------------------------

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -22,7 +22,6 @@
 // product writers
 #include <vtkPNGWriter.h>
 #include <vtkXMLDataObjectWriter.h>
-#include <ttkTopologicalCompressionWriter.h>
 
 // file lock
 #include <boost/interprocess/sync/file_lock.hpp>
@@ -430,11 +429,10 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       imageWriter->SetInputData(inputAsID);
       imageWriter->Write();
     } else {
-      auto topologicalCompressionWriter = vtkSmartPointer<ttkTopologicalCompressionWriter>::New();
-      topologicalCompressionWriter->SetFileName(
+      this->topologicalCompressionWriter->SetFileName(
         (this->DatabasePath + "/" + rDataProductPath).data());
-      topologicalCompressionWriter->SetInputData( input );
-      topologicalCompressionWriter->WriteData();
+      this->topologicalCompressionWriter->SetInputData(input);
+      this->topologicalCompressionWriter->WriteData();
     }
 
     this->printMsg("Writing data product to disk", 1, t.getElapsedTime(),

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -429,6 +429,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       imageWriter->SetInputData(inputAsID);
       imageWriter->Write();
     } else {
+      this->topologicalCompressionWriter->SetDebugLevel(this->debugLevel_);
       this->topologicalCompressionWriter->SetFileName(
         (this->DatabasePath + "/" + rDataProductPath).data());
       this->topologicalCompressionWriter->SetInputData(input);

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -42,6 +42,29 @@ public:
 
   int DeleteDatabase();
 
+  // TopologicalCompressionWriter options
+#define TopoCompWriterGetSetMacro(NAME, TYPE)               \
+  void Set##NAME(const TYPE _arg) {                         \
+    this->topologicalCompressionWriter->Set##NAME(_arg);    \
+    this->Modified();                                       \
+  }                                                         \
+  TYPE Get##NAME() {                                        \
+    return this->topologicalCompressionWriter->Get##NAME(); \
+  }
+
+  TopoCompWriterGetSetMacro(ScalarField, std::string);
+  TopoCompWriterGetSetMacro(Tolerance, double);
+  TopoCompWriterGetSetMacro(MaximumError, double);
+  TopoCompWriterGetSetMacro(ZFPBitBudget, double);
+  TopoCompWriterGetSetMacro(ZFPOnly, bool);
+  TopoCompWriterGetSetMacro(CompressionType, int);
+  TopoCompWriterGetSetMacro(Subdivide, bool);
+  TopoCompWriterGetSetMacro(UseTopologicalSimplification, bool);
+
+  void SetSQMethodPV(const int arg) {
+    this->topologicalCompressionWriter->SetSQMethodPV(arg);
+  }
+
 protected:
   ttkCinemaWriter();
   ~ttkCinemaWriter();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -14,9 +14,13 @@
 
 // VTK includes
 #include <ttkAlgorithm.h>
+#include <vtkNew.h>
 
 // VTK Module
 #include <ttkCinemaWriterModule.h>
+
+// TTK Writer
+#include <ttkTopologicalCompressionWriter.h>
 
 class TTKCINEMAWRITER_EXPORT ttkCinemaWriter : public ttkAlgorithm {
 
@@ -57,4 +61,5 @@ private:
   int CompressionLevel{5};
   bool IterateMultiBlock{true};
   int Mode{0};
+  vtkNew<ttkTopologicalCompressionWriter> topologicalCompressionWriter{};
 };

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -89,9 +89,6 @@ int ttkTopologicalCompressionReader::RequestData(
   if(FileName == nullptr) {
     return 1;
   }
-  if(fp != nullptr) {
-    return 1;
-  }
   fp = fopen(FileName, "rb"); // binary mode
   if(fp == nullptr) {
     return 1;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -97,13 +97,6 @@ void ttkTopologicalCompressionWriter::PerformCompression(
 }
 
 void ttkTopologicalCompressionWriter::WriteData() {
-  vtkDataObject *input = GetInput();
-  vtkImageData *vti = vtkImageData::SafeDownCast(input);
-
-  execute(vti);
-}
-
-void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
   bool zfpOnly = ZFPOnly;
   double zfpBitBudget = ZFPBitBudget;
   topologicalCompression.setThreadNumber(threadNumber_);
@@ -122,6 +115,9 @@ void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
     d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
     return;
   }
+
+  vtkDataObject *input = GetInput();
+  vtkImageData *vti = vtkImageData::SafeDownCast(input);
 
   vtkDataArray *inputScalarField = GetInputScalarField(vti);
 

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -130,7 +130,6 @@ protected:
   ~ttkTopologicalCompressionWriter();
   virtual int FillInputPortInformation(int port, vtkInformation *info) override;
   void WriteData() override;
-  void execute(vtkImageData *vti);
 
   // TTK management.
   vtkDataArray *GetInputScalarField(vtkImageData *vti);

--- a/paraview/CinemaQuery/CinemaQuery.xml
+++ b/paraview/CinemaQuery/CinemaQuery.xml
@@ -4,7 +4,7 @@
         <SourceProxy name="CinemaQuery" class="ttkCinemaQuery" label="TTK CinemaQuery">
             <Documentation long_help="TTK CinemaQuery" short_help="TTK CinemaQuery">This filter evaluates a SQL statement on multiple InputTables.</Documentation>
 
-            <InputProperty name="InputTable0" port_index="0" command="SetInputConnection">
+            <InputProperty name="InputTable" command="AddInputConnection" multiple_input="1">
                 <ProxyGroupDomain name="groups">
                     <Group name="sources" />
                     <Group name="filters" />
@@ -12,60 +12,7 @@
                 <DataTypeDomain name="input_type">
                     <DataType value="vtkTable" />
                 </DataTypeDomain>
-                <Documentation>'InputTable0' in SQL statement.</Documentation>
-            </InputProperty>
-
-            <InputProperty name="InputTable1" port_index="1" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <DataTypeDomain name="input_type">
-                    <DataType value="vtkTable" />
-                </DataTypeDomain>
-                <Documentation>'InputTable1' in SQL statement.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="InputTable2" port_index="2" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <DataTypeDomain name="input_type">
-                    <DataType value="vtkTable" />
-                </DataTypeDomain>
-                <Documentation>'InputTable2' in SQL statement.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="InputTable3" port_index="3" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <DataTypeDomain name="input_type">
-                    <DataType value="vtkTable" />
-                </DataTypeDomain>
-                <Documentation>'InputTable3' in SQL statement.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="InputTable4" port_index="4" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <DataTypeDomain name="input_type">
-                    <DataType value="vtkTable" />
-                </DataTypeDomain>
-                <Documentation>'InputTable4' in SQL statement.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
+                <Documentation>Input vtkTables to run the SQL statement on.</Documentation>
             </InputProperty>
 
             <StringVectorProperty name="SQLStatement" label="SQL Statement" command="SetSQLStatement" number_of_elements="1" default_values="SELECT * FROM InputTable0">

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -42,7 +42,7 @@ NOTE:
                     <Entry value="1" text="PNG Image"/>
                     <Entry value="2" text="TTK Compression"/>
                 </EnumerationDomain>
-                <Documentation>Store input as VTK file, PNG image, or TTK topological compression file.</Documentation>
+                <Documentation>Store input as VTK file or PNG image.</Documentation>
             </IntVectorProperty>
 
             <IntVectorProperty name="IterateMultiBlock" label="Iterate MultiBlock" command="SetIterateMultiBlock" number_of_elements="1" default_values="0">
@@ -62,6 +62,27 @@ NOTE:
             </PropertyGroup>
             <PropertyGroup panel_widget="Line" label="Commands">
                 <Property name="DeleteDatabase" />
+            </PropertyGroup>
+
+            ${TOPOLOGICAL_COMPRESSION_WIDGETS}
+
+            <PropertyGroup panel_widget="Line" label="Topological Compression" >
+              <Property name="ScalarField" />
+              <Property name="CompressionType" />
+              <Property name="Tolerance" />
+              <Property name="Subdivide" />
+              <Property name="MaximumError" />
+              <Property name="ZFPBitBudget" />
+              <Property name="ZFPOnly" />
+              <Property name="UseTopologicalSimplification" />
+              <Property name="SQMethod" />
+              <Hints>
+                <PropertyWidgetDecorator
+                    type="GenericDecorator"
+                    mode="visibility"
+                    property="Mode"
+                    value="2" />
+              </Hints>
             </PropertyGroup>
 
             ${DEBUG_WIDGETS}

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -42,7 +42,7 @@ NOTE:
                     <Entry value="1" text="PNG Image"/>
                     <Entry value="2" text="TTK Compression"/>
                 </EnumerationDomain>
-                <Documentation>Store input as VTK file or PNG image.</Documentation>
+                <Documentation>Store input as VTK file, a PNG image or a TTK compressed file.</Documentation>
             </IntVectorProperty>
 
             <IntVectorProperty name="IterateMultiBlock" label="Iterate MultiBlock" command="SetIterateMultiBlock" number_of_elements="1" default_values="0">

--- a/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
+++ b/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
@@ -30,24 +30,6 @@
       </InputProperty>
 
       <StringVectorProperty
-          name="ScalarField"
-          command="SetScalarField"
-          number_of_elements="1"
-          animateable="0"
-          label="Scalar Field">
-        <ArrayListDomain
-            name="array_list"
-            default_values="0">
-          <RequiredProperties>
-            <Property name="Input" function="Input" />
-          </RequiredProperties>
-        </ArrayListDomain>
-        <Documentation>
-          Select the scalar field to process.
-        </Documentation>
-      </StringVectorProperty>
-
-      <StringVectorProperty
         name="FileName"
         command="SetFileName"
         number_of_elements="1">
@@ -56,113 +38,8 @@
           This property specifies the file name for the OFF writer.
         </Documentation>
       </StringVectorProperty>
-      
-      <IntVectorProperty
-        name="CompressionType"
-        label="Compression type"
-        command="SetCompressionType"
-        number_of_elements="1"
-        default_values="0">
-        <EnumerationDomain name="enum">
-          <Entry value="0" text="Driven by persistence diagram"/>
-        </EnumerationDomain>
-        <Documentation>
-          Compression Type. 
-        </Documentation>
-      </IntVectorProperty>
-      
-      <DoubleVectorProperty
-          name="Tolerance"
-          command="SetTolerance"
-          label="Topological loss (persistence percentage)"
-          number_of_elements="1"
-          default_values="10">
-        <Documentation>
-          Topological loss expressed as a persistence threshold (normalized
-            between 0 and 100).
-        </Documentation>
-        <DoubleRangeDomain name="range" min="1" max="100" />
-      </DoubleVectorProperty>
 
-      <IntVectorProperty
-        name="Subdivide"
-        label="Enable maximum pointwise error control"
-        command="SetSubdivide"
-        number_of_elements="1"
-        default_values="0">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Enable maximum pointwise error control.
-        </Documentation>
-      </IntVectorProperty>
-      
-      <DoubleVectorProperty
-        name="MaximumError"
-        command="SetMaximumError"
-        label="Maximum pointwise error (percentage)"
-        number_of_elements="1"
-        default_values="10">
-        <Documentation>
-          Set the maximum allowed pointwise error (in percentage of the 
-            function span).
-        </Documentation>
-        <DoubleRangeDomain name="range" min="1" max="100" />
-      </DoubleVectorProperty>
-
-      <IntVectorProperty
-              name="ZFPBitBudget"
-              label="ZFP bit budget (extra)"
-              command="SetZFPBitBudget"
-              number_of_elements="1"
-              default_values="0">
-        <IntRangeDomain name="range" min="0" max="64" />
-        <Documentation>
-          Additionally compress the data with ZFP for improved geometrical
-            quality (number of bits per vertex).
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-              name="ZFPOnly"
-              label="Use ZFP compressor only (no topological compression)"
-              command="SetZFPOnly"
-              number_of_elements="1"
-              default_values="0">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Use ZFP only.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-        name="UseTopologicalSimplification"
-        label="Simplify at compression (slower)"
-        command="SetUseTopologicalSimplification"
-        number_of_elements="1"
-        default_values="1"
-        panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Enable topological simplification at compression time (higher 
-          compression factors, slower compression time).
-        </Documentation>
-      </IntVectorProperty>
-      
-      <IntVectorProperty
-        name="SQMethod"
-        command="SetSQMethodPV"
-        animateable="0"
-        label="Use SQ compressor only (no topological compression)"
-        panel_visibility="advanced">
-        <EnumerationDomain name="enum">
-          <Entry value="0" text="No SQ (topological compression)."/>
-          <Entry value="1" text="Range-based SQ (lowest quality, faster)."/>
-          <Entry value="2" text="Domain-based SQ (highest quality, slower)."/>
-        </EnumerationDomain>
-        <Documentation>
-          Use SQ instead of topological compression.
-        </Documentation>
-      </IntVectorProperty>
+      ${TOPOLOGICAL_COMPRESSION_WIDGETS}
 
       <IntVectorProperty
               name="UseAllCores"


### PR DESCRIPTION
Hi Jonas,

This PR contains the missing features in the Cinema filters to get to parity with TTK stable, as discussed in topology-tool-kit/ttk#304.

It includes:
* support reading TIFF images in Cinema databases,
* add Topological Compression options in CinemaWriter GUI,
* display the Topological compression reader and writer logs when used through Cinema,
* support writing multi-block datasets in CinemaWriter (for now I only write the first block).

I also took the liberty to make some small changes inside your filters:
* switch from `vtkSmartPointer` to `vtkNew` for the CinemaProductReader member variables. IMO `vtkNew` is better (and shorter to write) for owned pointers.
* extract the DEBUG_WIDGETS XML code into its own file for better readability and syntax highlighting (no more backslashes to wrap lines).
* modify the CinemaQuery input code to allow it to be applied to a selection of inputs in the ParaView pipeline browser. Now you can control-click several filters that output a vtkTable and apply CinemaQuery onto them without using "Change Input" to select additional tables. Incidentally, it can support more than 5 input tables now (it comes from Jules code for PersistenceDiagramClustering). It may breaks existing state files on your side though.

If you don't like those last changes, feel free to tell me, and I will revert or remove them.

Enjoy!
Pierre